### PR TITLE
Pass an higher amount of memory to asm.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var validator = require("validator");
 var ecdsa = new (require("elliptic").ec)("secp256k1");
 var pubToAddress = require("ethereumjs-util").pubToAddress;
 var keccak = require("./lib/keccak");
-var scrypt = require("./lib/scrypt")(67108864);
+var scrypt = require("./lib/scrypt")(280000000);
 
 // convert string to buffer
 function str2buf(str, enc) {


### PR DESCRIPTION
The new *Geth* keys use a bigger kdfparams.n and that requires more memory 

I believe this is true from geth 1.4+?

That's the error I get when decrypting a key (via the `recover` fn):

```
Cannot enlarge memory arrays in asm.js. Either (1) compile with -s TOTAL_MEMORY=X with X higher than the current value, or (2) set Module.TOTAL_MEMORY before the program runs.
undefined:1
"\uivat\u
   ^

SyntaxError: Unexpected token i
    at Object.parse (native)
    at hex2utf16le (./node_modules/keythereum/index.js:45:17)
    at Object.module.exports.getMAC (./node_modules/keythereum/index.js:162:17)
    at verifyAndDecrypt (./node_modules/keythereum/index.js:457:28)
    at Object.module.exports.recover (./node_modules/keythereum/index.js:501:20)
   ...
```

And this is the stacktrace of the abort() Error I get on the `deriveKey` function:

```
abort() at Error
    at Error (native)
    at wa (./node_modules/keythereum/lib/scrypt.js:11552:27)
    at Function.ua (./node_modules/keythereum/lib/scrypt.js:166:20)
    at nc (./node_modules/keythereum/lib/scrypt.js:1757:22)
    at bL (./node_modules/keythereum/lib/scrypt.js:4984:33)
    at Object.bu [as _crypto_scrypt] (./node_modules/keythereum/lib/scrypt.js:2776:33)
    at Object.crypto_scrypt (./node_modules/keythereum/lib/scrypt.js:11693:28)
    at Object.module.exports.deriveKey (./node_modules/keythereum/index.js:212:50)
    at Object.module.exports.recover (./node_modules/keythereum/index.js:501:30)
...
```

With the new value of 280MB it works without errors