### PR TITLE
Set scrypt memory in recover function

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,7 +438,8 @@ module.exports = {
         n: keyObjectCrypto.kdfparams.n,
         r: keyObjectCrypto.kdfparams.r,
         p: keyObjectCrypto.kdfparams.p,
-        dklen: keyObjectCrypto.kdfparams.dklen
+        dklen: keyObjectCrypto.kdfparams.dklen,
+        memory: 280000000
       };
     } else {
       if (keyObjectCrypto.kdfparams.prf !== "hmac-sha256") {


### PR DESCRIPTION
Trying to recover a key with kdfparams.n = 262144  in node goes out of memory.

Error:

`Cannot enlarge memory arrays in asm.js. Either (1) compile with -s TOTAL_MEMORY=X with X higher than the current value, or (2) set Module.TOTAL_MEMORY before the program runs.`

This PR fix this.