### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: node_js
 
 branches:


### PR DESCRIPTION
This PR updates the Travis CI configuration to remove the unneeded `sudo: false` option.

See also: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

> If you currently specify `sudo: false` in your `.travis.yml`, we recommend removing that configuration soon.