### PR TITLE
Add support for async/await in addition to callbacks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "es6": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/fixtures/state
 test/fixtures/nodes
 test/fixtures/geth
 test/browser/bundle.js
+.idea

--- a/index.js
+++ b/index.js
@@ -497,7 +497,7 @@ module.exports = {
    * @return {buffer} Plaintext private key.
    */
   recover: function (password, keyObject, cb) {
-    var keyObjectCrypto, iv, salt, ciphertext, algo, self = this;
+    var keyObjectCrypto, iv, salt, ciphertext, algo, decryptedKey, self = this;
     keyObjectCrypto = keyObject.Crypto || keyObject.crypto;
 
     // verify that message authentication codes match, then decrypt
@@ -539,7 +539,8 @@ module.exports = {
       return new Promise(function (resolve, reject) {
         this.deriveKey(password, salt, keyObjectCrypto, function (derivedKey) {
           try {
-            resolve(verifyAndDecrypt(derivedKey, salt, iv, ciphertext, algo));
+            decryptedKey = verifyAndDecrypt(derivedKey, salt, iv, ciphertext, algo);
+            resolve(decryptedKey);
           } catch (exc) {
             reject(exc);
           }

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ module.exports = {
       }
       // async - promise
       if (isTrue(cb)) {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
           setTimeout(function () {
             resolve(Buffer.from(sjcl.codec.hex.fromBits(sjcl.misc.pbkdf2(
               password.toString("utf8"),


### PR DESCRIPTION
Fixes #58

- [x] Promisfy deriveKeyUsingScryptInNode
- [x] Promisfy deriveKeyUsingScryptInBrowser
- [x] Promisfy deriveKey
- [x] Promisfy create
- [x] Promisfy dump
- [x] Promisfy recover
- [x] Promisfy exportToFile
- [x] Promisfy importFromFile
- [x] Add tests for all new promise use case
