### PR TITLE
New CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+(modification: no type change headlines) and this project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2020-09-29
+
+This is a maintenance release after a longer period with no releases.
+See PR [#81](https://github.com/ethereumjs/keythereum/pull/81) for implementation
+details.
+
+**Changes**
+
+- `scrypt` to [`scrypt-js`](https://github.com/ricmoo/scrypt-js) for a pure js implementation (simplifies some code)
+- `keccak` from `1.4.0` to `3.1.0` for node 12 and n-api support
+- `secp256k1` from `3.5.0` to `4.0.2` for node 12 and n-api support
+- travis ci node versions from `[4, 5, 6, 7, 8]` to `[8, 10, 12, 13, 14]`
+- uglify-js to [`terser`](https://github.com/terser/terser) (build was having some trouble with es6 in node_modules)
+- browserify from `16.2.2` to `16.5.2` for misc. bug fixes and upgrades.
+
+[1.2.0]: https://github.com/ethereumjs/keythereum/compare/v1.0.4...v1.2.0
+
+## [1.0.4]
+
+TODO
+
+## Older releases:
+
+- [1.x.x](https://github.com/ethereumjs/keythereum/compare/v1.x.x...v1.y.y) - 20xx-xx-xx
+- ...


### PR DESCRIPTION
@tinybike ah, just discovered that you already released. Was a bit confused since I had already prepared a release PR as well, then I will now just submit the new CHANGELOG file from this.

One question: also confused a bit that `dist` and `keystore` folders are included in your `v1.2.0` release but at the same time also included in `.npmignore`, so when I did `npm pack` these folders were actually omitted. Can we remove these from `.npmignore` therefore? Or is there otherwise a special "trick" to do releases? 😄 